### PR TITLE
Natural Time Parser

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@
  * For more details take a look at the Java Quickstart chapter in the Gradle
  * user guide available at http://gradle.org/docs/2.2.1/userguide/tutorial_java_projects.html
  */
- 
+
 plugins {
     id "com.github.kt3k.coveralls" version "2.4.0"
     id "com.github.johnrengelman.shadow" version '1.2.3'
@@ -54,6 +54,7 @@ allprojects {
         compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion"
         compile "com.google.guava:guava:$guavaVersion"
         compile "joda-time:joda-time:$jodatimeVersion"
+        compile "com.joestelmach:natty:0.12"
 
         testCompile "junit:junit:$junitVersion"
         testCompile "org.testfx:testfx-core:$testFxVersion"
@@ -63,7 +64,7 @@ allprojects {
         }
         testCompile "org.testfx:openjfx-monocle:$monocleVersion"
     }
-    
+
     sourceSets {
         main {
             java {
@@ -74,7 +75,7 @@ allprojects {
             }
         }
     }
-    
+
     shadowJar {
         archiveName = "doerList.jar"
 

--- a/src/main/java/seedu/doerList/logic/parser/TimeParser.java
+++ b/src/main/java/seedu/doerList/logic/parser/TimeParser.java
@@ -1,0 +1,32 @@
+package seedu.doerList.logic.parser;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+
+import com.joestelmach.natty.DateGroup;
+import com.joestelmach.natty.Parser;
+
+import seedu.doerList.commons.exceptions.IllegalValueException;
+
+public class TimeParser {
+
+    public static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm");
+
+    public static final String MESSAGE_NO_TIME_FOUND = "No time was found in the given String";
+
+    public TimeParser() {}
+    public static String parse(String s) throws IllegalValueException {
+        try {
+            Parser parser = new Parser();
+            List<DateGroup> dateGroups = parser.parse(s);
+            DateGroup group = dateGroups.get(0);
+            List<Date> dateList = group.getDates();
+            Date firstDate = dateList.get(0);
+
+            return dateFormat.format(firstDate);
+        } catch (IndexOutOfBoundsException ire) {
+            throw new IllegalValueException(MESSAGE_NO_TIME_FOUND);
+        }
+    }
+}

--- a/src/main/java/seedu/doerList/logic/parser/TimeParser.java
+++ b/src/main/java/seedu/doerList/logic/parser/TimeParser.java
@@ -15,15 +15,16 @@ public class TimeParser {
     public static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm");
 
     public TimeParser() {}
-    public static String parse(String s) throws IllegalValueException {
+    
+    public String parse(String s) throws IllegalValueException {
         try {
             Parser parser = new Parser();
             List<DateGroup> dateGroups = parser.parse(s);
-            DateGroup group = dateGroups.get(0);
+            DateGroup group = dateGroups.get(dateGroups.size() - 1);
             List<Date> dateList = group.getDates();
-            Date firstDate = dateList.get(0);
+            Date lastDate = dateList.get(dateList.size() - 1);
 
-            return dateFormat.format(firstDate);
+            return dateFormat.format(lastDate);
         } catch (IndexOutOfBoundsException ire) {
             throw new IllegalValueException(TodoTime.MESSAGE_TODOTIME_CONSTRAINTS);
         }

--- a/src/main/java/seedu/doerList/logic/parser/TimeParser.java
+++ b/src/main/java/seedu/doerList/logic/parser/TimeParser.java
@@ -8,12 +8,11 @@ import com.joestelmach.natty.DateGroup;
 import com.joestelmach.natty.Parser;
 
 import seedu.doerList.commons.exceptions.IllegalValueException;
+import seedu.doerList.model.task.TodoTime;
 
 public class TimeParser {
 
     public static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm");
-
-    public static final String MESSAGE_NO_TIME_FOUND = "No time was found in the given String";
 
     public TimeParser() {}
     public static String parse(String s) throws IllegalValueException {
@@ -26,7 +25,7 @@ public class TimeParser {
 
             return dateFormat.format(firstDate);
         } catch (IndexOutOfBoundsException ire) {
-            throw new IllegalValueException(MESSAGE_NO_TIME_FOUND);
+            throw new IllegalValueException(TodoTime.MESSAGE_TODOTIME_CONSTRAINTS);
         }
     }
 }

--- a/src/main/java/seedu/doerList/model/task/TodoTime.java
+++ b/src/main/java/seedu/doerList/model/task/TodoTime.java
@@ -16,7 +16,6 @@ public class TodoTime {
     public final DateTime value;
 
     public static final String MESSAGE_TODOTIME_CONSTRAINTS = "Time should be in this format 'yyyy-MM-dd HH:mm' or natural language such as 'tomorrow', 'next week monday'";
-    public static final String TODOTIME_VALIDATION_REGEX = "\\d\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d";
     public static final String TIME_STANDARD_FORMAT = "yyyy-MM-dd HH:mm";
 
     /**
@@ -36,13 +35,6 @@ public class TodoTime {
 
    public TodoTime(DateTime source) {
        value = source;
-   }
-
-   /**
-    * Returns true if a given string is a valid time.
-    */
-   public static boolean isValidTime(String test) {
-       return test != null && test.matches(TODOTIME_VALIDATION_REGEX);
    }
 
    /**

--- a/src/main/java/seedu/doerList/model/task/TodoTime.java
+++ b/src/main/java/seedu/doerList/model/task/TodoTime.java
@@ -25,12 +25,9 @@ public class TodoTime {
     */
    public TodoTime(String rawTime) throws IllegalValueException {
        DateTimeFormatter formatter = DateTimeFormat.forPattern(TIME_STANDARD_FORMAT);
-       try {
-           String time = TimeParser.parse(rawTime);
-           value = DateTime.parse(time, formatter);
-       } catch (IllegalArgumentException ire) {
-           throw new IllegalValueException(MESSAGE_TODOTIME_CONSTRAINTS);
-       }
+       String time = TimeParser.parse(rawTime);
+       value = DateTime.parse(time, formatter);
+
    }
 
    public TodoTime(DateTime source) {

--- a/src/main/java/seedu/doerList/model/task/TodoTime.java
+++ b/src/main/java/seedu/doerList/model/task/TodoTime.java
@@ -3,6 +3,7 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 import seedu.doerList.commons.exceptions.IllegalValueException;
+import seedu.doerList.logic.parser.TimeParser;
 
 import org.joda.time.DateTime;
 
@@ -14,10 +15,10 @@ public class TodoTime {
 
     public final DateTime value;
 
-    public static final String MESSAGE_TODOTIME_CONSTRAINTS = "Time should be in this format 'yyyy-MM-dd HH:mm'";
+    public static final String MESSAGE_TODOTIME_CONSTRAINTS = "Time should be in this format 'yyyy-MM-dd HH:mm' or natural language such as 'tomorrow', 'next week monday'";
     public static final String TODOTIME_VALIDATION_REGEX = "\\d\\d\\d\\d-\\d\\d-\\d\\d \\d\\d:\\d\\d";
     public static final String TIME_STANDARD_FORMAT = "yyyy-MM-dd HH:mm";
-    
+
     /**
     * Validates given rawTime.
     *
@@ -26,12 +27,13 @@ public class TodoTime {
    public TodoTime(String rawTime) throws IllegalValueException {
        DateTimeFormatter formatter = DateTimeFormat.forPattern(TIME_STANDARD_FORMAT);
        try {
-           value = DateTime.parse(rawTime, formatter); 
+           String time = TimeParser.parse(rawTime);
+           value = DateTime.parse(time, formatter);
        } catch (IllegalArgumentException ire) {
            throw new IllegalValueException(MESSAGE_TODOTIME_CONSTRAINTS);
        }
    }
-   
+
    public TodoTime(DateTime source) {
        value = source;
    }

--- a/src/main/java/seedu/doerList/model/task/TodoTime.java
+++ b/src/main/java/seedu/doerList/model/task/TodoTime.java
@@ -25,7 +25,7 @@ public class TodoTime {
     */
    public TodoTime(String rawTime) throws IllegalValueException {
        DateTimeFormatter formatter = DateTimeFormat.forPattern(TIME_STANDARD_FORMAT);
-       String time = TimeParser.parse(rawTime);
+       String time = new TimeParser().parse(rawTime);
        value = DateTime.parse(time, formatter);
 
    }

--- a/src/test/java/seedu/doerList/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/doerList/logic/LogicManagerTest.java
@@ -263,14 +263,14 @@ public class LogicManagerTest {
     public void execute_list_buildInCategory() throws Exception {
         // prepare expectations
         TestDataHelper helper = new TestDataHelper();
-        Task Today1 = helper.generateTaskWithTime(1, new DateTime().withHourOfDay(8), 
-                        new DateTime().withHourOfDay(12)); // today
-        Task Next7Days1 = helper.generateTaskWithTime(2, new DateTime().withHourOfDay(8).plusDays(1), 
-                        new DateTime().withHourOfDay(12).plusDays(1)); // tomorrow
-        Task Next7Days2 = helper.generateTaskWithTime(3, new DateTime().withHourOfDay(8).plusDays(5), 
-                        new DateTime().withHourOfDay(12).plusDays(5)); // next 5 days
-        Task Next7Days3 = helper.generateTaskWithTime(3, new DateTime().withHourOfDay(8).plusDays(7), 
-                        new DateTime().withHourOfDay(12).plusDays(7)); // next 7 days
+        Task Today1 = helper.generateTaskWithTime(1, new DateTime().withHourOfDay(8).toString(), 
+                        new DateTime().withHourOfDay(12).toString()); // today
+        Task Next7Days1 = helper.generateTaskWithTime(2, new DateTime().withHourOfDay(8).plusDays(1).toString(), 
+                        new DateTime().withHourOfDay(12).plusDays(1).toString()); // tomorrow
+        Task Next7Days2 = helper.generateTaskWithTime(3, new DateTime().withHourOfDay(8).plusDays(5).toString(), 
+                        new DateTime().withHourOfDay(12).plusDays(5).toString()); // next 5 days
+        Task Next7Days3 = helper.generateTaskWithTime(3, new DateTime().withHourOfDay(8).plusDays(7).toString(), 
+                        new DateTime().withHourOfDay(12).plusDays(7).toString()); // next 7 days
         Task Inbox1 = helper.generateTaskWithTime(4, null, null); // inbox
         Task Complete1 = helper.generateTaskWithCategory(5); // complete
         Complete1.addBuildInCategory(BuildInCategoryList.COMPLETE);
@@ -606,7 +606,7 @@ public class LogicManagerTest {
          * @param endTime
          * @return
          */
-        Task generateTaskWithTime(int seed, DateTime startTime, DateTime endTime) {
+        Task generateTaskWithTime(int seed, String startTime, String endTime) {
             try {
                 return new Task(
                         new Title("Task " + seed),

--- a/src/test/java/seedu/doerList/logic/TimeParserTest.java
+++ b/src/test/java/seedu/doerList/logic/TimeParserTest.java
@@ -1,0 +1,52 @@
+package seedu.doerList.logic;
+
+import static org.junit.Assert.*;
+import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.junit.Before;
+import org.junit.Test;
+import seedu.doerList.commons.exceptions.IllegalValueException;
+import seedu.doerList.logic.parser.TimeParser;
+import seedu.doerList.model.task.TodoTime;
+
+public class TimeParserTest {
+    private TimeParser parser;
+    private DateTimeFormatter formatter;
+    
+    @Before
+    public void setup() {
+        parser = new TimeParser();
+        formatter = DateTimeFormat.forPattern(TodoTime.TIME_STANDARD_FORMAT);
+    }
+    
+    public void parse_withExplicitDateTime_successful() {
+        DateTime now = new DateTime();
+        assertEquals(now.toString(formatter), now.toString(formatter));
+    }
+    
+    @Test
+    public void parse_withImplicitDate_successful() throws IllegalValueException {
+        assertEquals(parser.parse("today"), new DateTime().toString(formatter));
+        assertEquals(parser.parse("tomorrow"), new DateTime().plusDays(1).toString(formatter));
+    }
+    
+    @Test
+    public void parse_withTime_successful() throws IllegalValueException {
+        assertEquals(parser.parse("today 5pm"), 
+                new DateTime().withHourOfDay(17).withMinuteOfHour(0).toString(formatter));
+        assertEquals(parser.parse("today 17:20"),
+                new DateTime().withHourOfDay(17).withMinuteOfHour(20).toString(formatter));
+        assertEquals(parser.parse("today 5:20pm"),
+                new DateTime().withHourOfDay(17).withMinuteOfHour(20).toString(formatter));
+    }
+    
+    @Test
+    public void parse_withImplicitTime_successful() throws IllegalValueException {
+        assertEquals(parser.parse("next 2 hours"), new DateTime().plusHours(2).toString(formatter));
+        assertEquals(parser.parse("next 2 days"), new DateTime().plusDays(2).toString(formatter));
+        assertEquals(parser.parse("next 2 months"), new DateTime().plusMonths(2).toString(formatter));
+        assertEquals(parser.parse("next week"), new DateTime().plusDays(7).toString(formatter));
+        assertEquals(parser.parse("next months"), new DateTime().plusMonths(1).toString(formatter));
+    }
+}


### PR DESCRIPTION
Add and edit now accept natural language for time such as "tomorrow", "the day after tomorrow", "the day before next week Wednesday". If no time is found in the string, return message "No time was found in your string"

* Possible improvement for the future. I will implement that if hour and minute is not called like "tomorrow" instead of "tomorrow 5pm", the time will set to "tomorrow 23:59"

@xpdavid Will write test cases for add and edit for both this and 'taskdue' later. I am very sick now I am going to see the doctor again. Could barely code and do anything past few hours.

Rest assured the IMPLEMENTATION IS CORRECT in all cases HAHAHA